### PR TITLE
Adding example to commit nightly to gh-pages

### DIFF
--- a/.github/workflows/automated.yml
+++ b/.github/workflows/automated.yml
@@ -1,0 +1,39 @@
+name: automatied-sourcecred
+
+on:
+  schedule:
+    # Nightly at 2:30am 
+    - cron: 30 2 * * *
+
+jobs:
+  GenerateSourcecred:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v1
+    - name: Build the Docker image
+      env:
+        TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        SOURCECRED_GITHUB_TOKEN=${TOKEN} docker run -i -v sourcecred_data:/data -e SOURCECRED_GITHUB_TOKEN sourcecred/sourcecred:dev load ${GITHUB_REPOSITORY}
+        SOURCECRED_GITHUB_TOKEN=${TOKEN} docker run -i -v sourcecred_data:/data sourcecred/sourcecred:dev scores ${GITHUB_REPOSITORY} > scores.json
+        SOURCECRED_GITHUB_TOKEN=${TOKEN} docker run -i -e SOURCECRED_GITHUB_TOKEN sourcecred/widgets < scores.json > contributors.svg
+        cat contributors.svg
+    - name: Checkout New Branch
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        UPDATE_BRANCH: gh-pages
+      run: |
+        echo "GitHub Actor: ${GITHUB_ACTOR}"
+        git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+        git branch
+        echo "Branch to push to is ${UPDATE_BRANCH}"
+        git checkout -b ${UPDATE_BRANCH}
+        git branch
+
+        git config --global user.name "github-actions"
+        git config --global user.email "github-actions@users.noreply.github.com"
+
+        git add contributors.svg
+        git commit -m "Automated deployment to update contributors.svg $(date '+%Y-%m-%d')" --allow-empty
+        git push origin ${UPDATE_BRANCH}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,4 @@
-name: Generate-SourceCred
+name: generate-with-pull-request
 
 on:
   schedule:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,4 @@
-name: generate-with-pull-request
+name: pull-request-sourcecred
 
 on:
   schedule:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sourcecred Action
 
-[![GitHub actions status](https://github.com/sourcecred/sourcecred-action/workflows/generate-with-pull-request/badge.svg?branch=master)](https://github.com/sourcecred/sourcecred-action/actions?query=branch%3Amaster+workflow%3Agenerate-with-pull-request)
+[![GitHub actions status](https://github.com/sourcecred/sourcecred-action/workflows/pull-request-sourcecred/badge.svg?branch=master)](https://github.com/sourcecred/sourcecred-action/actions?query=branch%3Amaster+workflow%3Apull-request-sourcecred)
 
 This is a GitHub action to generate a beautiful [sourcecred](https://www.github.com/sourcecred/sourcecred)
 contributors graphic, using the sourcecred [widgets](https://www.github.com/sourcecred/widgets) containers. The git history for this repository is fairly limited, but with more contributors the graphic below would be much more substantial!

--- a/README.md
+++ b/README.md
@@ -1,27 +1,37 @@
 # Sourcecred Action
 
-[![GitHub actions status](https://github.com/sourcecred/sourcecred-action/workflows/Generate-SourceCred/badge.svg?branch=master)](https://github.com/sourcecred/sourcecred-action/actions?query=branch%3Amaster+workflow%3AGenerate-SourceCred)
+[![GitHub actions status](https://github.com/sourcecred/sourcecred-action/workflows/generate-with-pull-request/badge.svg?branch=master)](https://github.com/sourcecred/sourcecred-action/actions?query=branch%3Amaster+workflow%3Agenerate-with-pull-request)
 
 This is a GitHub action to generate a beautiful [sourcecred](https://www.github.com/sourcecred/sourcecred)
-contributors graphic, using the sourcecred [widgets](https://www.github.com/sourcecred/widgets) containers. The git history for this repository is fairly limited, but
-with more contributors the graphic below would be much more substantial!
+contributors graphic, using the sourcecred [widgets](https://www.github.com/sourcecred/widgets) containers. The git history for this repository is fairly limited, but with more contributors the graphic below would be much more substantial!
 
 ![contributors.svg](./contributors.svg)
 
-## Usage
+## 1. Choose your workflow
 
-### Add the workflow
+There are currently two derivations of the same workflow:
 
-Add the [.github/workflows/generate.yml](.github/workflows/generate.yml) to your repository, along with the [.github/workflows/pull_request.sh](.github/workflows/pull_request.sh) in the same folder.
+ - [.github/workflows/pull_request.yml](.github/workflows/pull_request.yml) can be added to your repository to run a scheduled job to open a pull request to update the graphic. This strategy allows you to review the changes by opening a new branch with the updated graphic, and is ideal if you don't want your repository being updated automatically. If you use this method, you'll also need to add the [.github/workflows/pull_request.sh](.github/workflows/pull_request.sh) file in the same folder.
+ - [.github/workflows/automated.yml](.github/workflows/automated.yml) runs the same logic, but pushes directly to a branch of your choosing (gh-pages for the repository here, and you can change this with the `UPDATE_BRANCH` variable.
 
-### Customize
+## 2. Customize
+
+### pull_request.yml and automated.yml
+
+ - **time**: you might want to adjust the cron frequency to be run at a rate that works for you . The pull request example is set to run on a weekly basis, and the automated example runs nightly at 2:30am, pushing to github pages.
+ - **filename**: the graphic is saved as contributors.svg at the root of the repository, and you can change this if desired.
+
+### pull_request.yml
 
 You might want to customize the workflow in the following ways:
 
- - **time**: you might want to adjust the cron frequency to be run at a rate that works for you (currently it's done on a daily basis at 8am).
  - **script for PR**: The script to open the pull request is obtained from [here](https://gist.githubusercontent.com/vsoch/074f4895e52f7fa0574a3a7a51d5c9d8/raw/ddfedf86abd2b78332b955325d5d93f37d1353b4/pull_request.sh). If you want more control over this script (or just to keep it alongside your repository) you can add it to your repository, and then interact with it directly during the Action.
  - **branches**: currently the pull request is done via a created branch called update/sourcecred-<date> and then done against master. You can update the Action to adjust these values.
- - **filename**: the graphic is saved as contributors.png at the root of the repository, and you can change this if desired.
+
+### automated.yml
+
+ - **branch** You can customize the branch that is pushed to by changing `UPDATE_BRANCH`.
+
 
 ### README
 


### PR DESCRIPTION
This will add an example action that is scheduled to run nightly (or at some frequency) to update the graphic on some branch like GitHub pages. It is currently set to run at 2:30am, so the first test will be early tomorrow morning!

This will close #17 

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>