### PR TITLE
Adding simple test to cache data

### DIFF
--- a/.github/workflows/automated.yml
+++ b/.github/workflows/automated.yml
@@ -11,6 +11,12 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v1
+    - name: Cache Data
+      id: cache-data
+      uses: actions/cache@v1
+      with:
+        path: sourcecred_data
+        key: ${{ runner.os }}-sourcecred_data
     - name: Build the Docker image
       env:
         TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,9 +1,9 @@
 name: pull-request-sourcecred
 
-on:
-  schedule:
-    # Weekly on Sunday
-    - cron: 0 0 * * 0
+on: [pull_request]
+#  schedule:
+#    # Weekly on Sunday
+#    - cron: 0 0 * * 0
 
 jobs:
   GenerateSourcecred:
@@ -11,6 +11,12 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v1
+    - name: Cache Data
+      id: cache-data
+      uses: actions/cache@v1
+      with:
+        path: sourcecred_data
+        key: ${{ runner.os }}-sourcecred_data
     - name: Build the Docker image
       env:
         TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,8 +21,9 @@ jobs:
       env:
         TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        SOURCECRED_GITHUB_TOKEN=${TOKEN} docker run -i -v sourcecred_data:/data -e SOURCECRED_GITHUB_TOKEN sourcecred/sourcecred:dev load ${GITHUB_REPOSITORY}
-        SOURCECRED_GITHUB_TOKEN=${TOKEN} docker run -i -v sourcecred_data:/data sourcecred/sourcecred:dev scores ${GITHUB_REPOSITORY} > scores.json
+        mkdir -p sourcecred_data
+        SOURCECRED_GITHUB_TOKEN=${TOKEN} docker run -i -v $PWD/sourcecred_data:/data -e SOURCECRED_GITHUB_TOKEN sourcecred/sourcecred:dev load ${GITHUB_REPOSITORY}
+        SOURCECRED_GITHUB_TOKEN=${TOKEN} docker run -i -v $PWD/sourcecred_data:/data sourcecred/sourcecred:dev scores ${GITHUB_REPOSITORY} > scores.json
         SOURCECRED_GITHUB_TOKEN=${TOKEN} docker run -i -e SOURCECRED_GITHUB_TOKEN sourcecred/widgets < scores.json > contributors.svg
         cat contributors.svg
     - name: Checkout New Branch

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,9 +1,9 @@
 name: pull-request-sourcecred
 
-on: [pull_request]
-#  schedule:
-#    # Weekly on Sunday
-#    - cron: 0 0 * * 0
+on:
+  schedule:
+    # Weekly on Sunday
+    - cron: 0 0 * * 0
 
 jobs:
   GenerateSourcecred:


### PR DESCRIPTION
This will use the [cache](https://github.com/actions/cache) action provided by GitHub to cache sourcecred_data. I might need to edit master branch to have the PR action trigger on PR (and not cron) to test this out.

Signed-off-by: Vanessa Sochat <vsochat@stanford.edu>