### PR TITLE
restoring checkout of update branch to be a new branch

### DIFF
--- a/.github/workflows/contributors_automated.yml
+++ b/.github/workflows/contributors_automated.yml
@@ -34,13 +34,13 @@ jobs:
         git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
         git branch
         printf "Branch to push to is ${UPDATE_BRANCH}\n"
-        git checkout -b ${UPDATE_BRANCH} || git checkout ${UPDATE_BRANCH}
+        git checkout -b "${UPDATE_BRANCH}"
         git branch
 
         git config --global user.name "github-actions"
         git config --global user.email "github-actions@users.noreply.github.com"
 
-        git pull origin ${UPDATE_BRANCH} || printf "Branch not yet on remote\n"
+        git pull origin ${UPDATE_BRANCH} || echo "Branch not yet on remote"
         git add contributors.svg
 
         if git diff-index --quiet HEAD --; then

--- a/.github/workflows/prototype_automated.yml
+++ b/.github/workflows/prototype_automated.yml
@@ -44,13 +44,13 @@ jobs:
         git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
         git branch
         printf "Branch to push to is ${UPDATE_BRANCH}\n"
-        git checkout -b ${UPDATE_BRANCH} || git checkout ${UPDATE_BRANCH}
+        git checkout -b ${UPDATE_BRANCH}
         git branch
 
         git config --global user.name "github-actions"
         git config --global user.email "github-actions@users.noreply.github.com"
 
-        git pull origin ${UPDATE_BRANCH} || printf "Branch not yet on remote\n"
+        git pull origin ${UPDATE_BRANCH} || echo "Branch not yet on remote"
         git add docs/*
 
         if git diff-index --quiet HEAD --; then


### PR DESCRIPTION
previously we had just git checkout -b <branch> and this worked because the branch was not fetched on the github actions host - adding the OR to checkout an existing branch seems to have triggered an error. All I am doing here is restoring those lines in both recipes to what they used to be. It's a little confusing looking at the Actions tab because although there was a failure yesterday, the contributors graphic was updated, so perhaps this was the day before? Here is the previously working version of one of the files https://github.com/sourcecred/sourcecred-action/blob/b9e2bdb4fac6f0f809adf35098bdd9220aed6e06/.github/workflows/contributors_automated.yml#L25. If it triggered again, we might want to grab changes before we run the containers.

Signed-off-by: vsoch <vsochat@stanford.edu>